### PR TITLE
Additional features

### DIFF
--- a/src/afl_cmd_gen.rs
+++ b/src/afl_cmd_gen.rs
@@ -218,7 +218,7 @@ impl AFLCmdGenerator {
             afl_binary,
             cmpcov_idxs: Vec::new(),
             ramdisk: rdisk,
-            use_afl_defaults: use_afl_defaults
+            use_afl_defaults
         }
     }
 

--- a/src/afl_cmd_gen.rs
+++ b/src/afl_cmd_gen.rs
@@ -286,10 +286,7 @@ impl AFLCmdGenerator {
         let mut cmds = self.create_initial_cmds(&configs)?;
 
         let afl_env_vars: Vec<String> = Self::get_afl_env_vars();
-        let mut is_using_custom_mutator: bool = false;
-        if afl_env_vars.iter().any(|e| e.starts_with("AFL_CUSTOM_MUTATOR_LIBRARY")){
-            is_using_custom_mutator = true;
-        }
+        let is_using_custom_mutator = if afl_env_vars.iter().any(|e| e.starts_with("AFL_CUSTOM_MUTATOR_LIBRARY")) { true } else { false };
         if ! self.use_afl_defaults {
             Self::apply_mutation_strategies(&mut cmds, &mut rng, is_using_custom_mutator);
             Self::apply_queue_selection(&mut cmds, &mut rng);

--- a/src/afl_env.rs
+++ b/src/afl_env.rs
@@ -47,13 +47,13 @@ impl FromStr for AFLFlag {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "AFL_AUTORESUME" => Ok(AFLFlag::AutoResume),
-            "AFL_FINAL_SYNC" => Ok(AFLFlag::FinalSync),
-            "AFL_DISABLE_TRIM" => Ok(AFLFlag::DisableTrim),
-            "AFL_KEEP_TIMEOUTS" => Ok(AFLFlag::KeepTimeouts),
-            "AFL_EXPAND_HAVOC_NOW" => Ok(AFLFlag::ExpandHavocNow),
-            "AFL_IGNORE_SEED_PROBLEMS" => Ok(AFLFlag::IgnoreSeedProblems),
-            "AFL_IMPORT_FIRST" => Ok(AFLFlag::ImportFirst),
+            "AFL_AUTORESUME" => Ok(Self::AutoResume),
+            "AFL_FINAL_SYNC" => Ok(Self::FinalSync),
+            "AFL_DISABLE_TRIM" => Ok(Self::DisableTrim),
+            "AFL_KEEP_TIMEOUTS" => Ok(Self::KeepTimeouts),
+            "AFL_EXPAND_HAVOC_NOW" => Ok(Self::ExpandHavocNow),
+            "AFL_IGNORE_SEED_PROBLEMS" => Ok(Self::IgnoreSeedProblems),
+            "AFL_IMPORT_FIRST" => Ok(Self::ImportFirst),
             _ => Err(format!("Unknown AFL flag: {}", s)),
         }
     }

--- a/src/afl_env.rs
+++ b/src/afl_env.rs
@@ -54,7 +54,7 @@ impl FromStr for AFLFlag {
             "AFL_EXPAND_HAVOC_NOW" => Ok(Self::ExpandHavocNow),
             "AFL_IGNORE_SEED_PROBLEMS" => Ok(Self::IgnoreSeedProblems),
             "AFL_IMPORT_FIRST" => Ok(Self::ImportFirst),
-            _ => Err(format!("Unknown AFL flag: {}", s)),
+            _ => Err(format!("Unknown AFL flag: {s}")),
         }
     }
 }

--- a/src/afl_env.rs
+++ b/src/afl_env.rs
@@ -2,7 +2,7 @@
 // AFLPlusPlus flags
 // Based on: https://aflplus.plus/docs/env_variables/
 // -----------------------------------------
-use std::collections::HashSet;
+use std::{collections::HashSet, str::FromStr};
 
 /// Enum representing the different AFL environment flags
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -25,6 +25,38 @@ pub enum AFLFlag {
     /// When setting `AFL_IMPORT_FIRST`, test cases from other fuzzers in the campaign are loaded first.
     /// Note: This can slow down the start of the first fuzz by quite a lot if you have many fuzzers and/or many seeds.
     ImportFirst,
+}
+
+impl ToString for AFLFlag {
+    fn to_string(&self) -> String {
+        match self {
+            AFLFlag::AutoResume => "AFL_AUTORESUME",
+            AFLFlag::FinalSync => "AFL_FINAL_SYNC",
+            AFLFlag::DisableTrim => "AFL_DISABLE_TRIM",
+            AFLFlag::KeepTimeouts => "AFL_KEEP_TIMEOUTS",
+            AFLFlag::ExpandHavocNow => "AFL_EXPAND_HAVOC_NOW",
+            AFLFlag::IgnoreSeedProblems => "AFL_IGNORE_SEED_PROBLEMS",
+            AFLFlag::ImportFirst => "AFL_IMPORT_FIRST",
+        }
+        .to_string()
+    }
+}
+
+impl FromStr for AFLFlag {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "AFL_AUTORESUME" => Ok(AFLFlag::AutoResume),
+            "AFL_FINAL_SYNC" => Ok(AFLFlag::FinalSync),
+            "AFL_DISABLE_TRIM" => Ok(AFLFlag::DisableTrim),
+            "AFL_KEEP_TIMEOUTS" => Ok(AFLFlag::KeepTimeouts),
+            "AFL_EXPAND_HAVOC_NOW" => Ok(AFLFlag::ExpandHavocNow),
+            "AFL_IGNORE_SEED_PROBLEMS" => Ok(AFLFlag::IgnoreSeedProblems),
+            "AFL_IMPORT_FIRST" => Ok(AFLFlag::ImportFirst),
+            _ => Err(format!("Unknown AFL flag: {}", s)),
+        }
+    }
 }
 
 /// Struct representing the environment variables for `AFLPlusPlus`
@@ -51,11 +83,6 @@ impl AFLEnv {
         self.flags.insert(flag);
     }
 
-    /// Checks if the specified AFL flag is enabled
-    pub fn is_flag_enabled(&self, flag: &AFLFlag) -> bool {
-        self.flags.contains(flag)
-    }
-
     /// Generates an `AFLPlusPlus` environment variable string for the current settings
     pub fn generate_afl_env_cmd(&self, ramdisk: Option<String>) -> Vec<String> {
         let mut command = Vec::new();
@@ -63,40 +90,9 @@ impl AFLEnv {
         if let Some(ramdisk) = ramdisk {
             command.push(format!("AFL_TMPDIR={} ", ramdisk));
         }
-        if self.is_flag_enabled(&AFLFlag::AutoResume){
-            command.push(format!(
-                "AFL_AUTORESUME=1 "
-            ));
-        }
-        if self.is_flag_enabled(&AFLFlag::FinalSync){
-            command.push(format!(
-                "AFL_FINAL_SYNC=1 "
-            ));
-        }
-        if self.is_flag_enabled(&AFLFlag::DisableTrim){
-            command.push(format!(
-                "AFL_DISABLE_TRIM=1 "
-            ));
-        }
-        if self.is_flag_enabled(&AFLFlag::KeepTimeouts){
-            command.push(format!(
-                "AFL_KEEP_TIMEOUTS=1 "
-            ));
-        }
-        if self.is_flag_enabled(&AFLFlag::ExpandHavocNow){
-            command.push(format!(
-                "AFL_EXPAND_HAVOC_NOW=1 "
-            ));
-        }
-        if self.is_flag_enabled(&AFLFlag::IgnoreSeedProblems){
-            command.push(format!(
-                "AFL_IGNORE_SEED_PROBLEMS=1 "
-            ));
-        }
-        if self.is_flag_enabled(&AFLFlag::ImportFirst){
-            command.push(format!(
-                "AFL_IMPORT_FIRST=1 "
-            ));
+
+        for flag in &self.flags {
+            command.push(format!("{}=1", flag.to_string()));
         }
 
         command.push(format!("AFL_TESTCACHE_SIZE={} ", self.testcache_size));

--- a/src/afl_env.rs
+++ b/src/afl_env.rs
@@ -30,13 +30,13 @@ pub enum AFLFlag {
 impl ToString for AFLFlag {
     fn to_string(&self) -> String {
         match self {
-            AFLFlag::AutoResume => "AFL_AUTORESUME",
-            AFLFlag::FinalSync => "AFL_FINAL_SYNC",
-            AFLFlag::DisableTrim => "AFL_DISABLE_TRIM",
-            AFLFlag::KeepTimeouts => "AFL_KEEP_TIMEOUTS",
-            AFLFlag::ExpandHavocNow => "AFL_EXPAND_HAVOC_NOW",
-            AFLFlag::IgnoreSeedProblems => "AFL_IGNORE_SEED_PROBLEMS",
-            AFLFlag::ImportFirst => "AFL_IMPORT_FIRST",
+            Self::AutoResume => "AFL_AUTORESUME",
+            Self::FinalSync => "AFL_FINAL_SYNC",
+            Self::DisableTrim => "AFL_DISABLE_TRIM",
+            Self::KeepTimeouts => "AFL_KEEP_TIMEOUTS",
+            Self::ExpandHavocNow => "AFL_EXPAND_HAVOC_NOW",
+            Self::IgnoreSeedProblems => "AFL_IGNORE_SEED_PROBLEMS",
+            Self::ImportFirst => "AFL_IMPORT_FIRST",
         }
         .to_string()
     }

--- a/src/afl_env.rs
+++ b/src/afl_env.rs
@@ -88,7 +88,7 @@ impl AFLEnv {
         let mut command = Vec::new();
 
         if let Some(ramdisk) = ramdisk {
-            command.push(format!("AFL_TMPDIR={} ", ramdisk));
+            command.push(format!("AFL_TMPDIR={ramdisk} "));
         }
 
         for flag in &self.flags {

--- a/src/afl_env.rs
+++ b/src/afl_env.rs
@@ -63,35 +63,42 @@ impl AFLEnv {
         if let Some(ramdisk) = ramdisk {
             command.push(format!("AFL_TMPDIR={} ", ramdisk));
         }
+        if self.is_flag_enabled(&AFLFlag::AutoResume){
+            command.push(format!(
+                "AFL_AUTORESUME=1 "
+            ));
+        }
+        if self.is_flag_enabled(&AFLFlag::FinalSync){
+            command.push(format!(
+                "AFL_FINAL_SYNC=1 "
+            ));
+        }
+        if self.is_flag_enabled(&AFLFlag::DisableTrim){
+            command.push(format!(
+                "AFL_DISABLE_TRIM=1 "
+            ));
+        }
+        if self.is_flag_enabled(&AFLFlag::KeepTimeouts){
+            command.push(format!(
+                "AFL_KEEP_TIMEOUTS=1 "
+            ));
+        }
+        if self.is_flag_enabled(&AFLFlag::ExpandHavocNow){
+            command.push(format!(
+                "AFL_EXPAND_HAVOC_NOW=1 "
+            ));
+        }
+        if self.is_flag_enabled(&AFLFlag::IgnoreSeedProblems){
+            command.push(format!(
+                "AFL_IGNORE_SEED_PROBLEMS=1 "
+            ));
+        }
+        if self.is_flag_enabled(&AFLFlag::ImportFirst){
+            command.push(format!(
+                "AFL_IMPORT_FIRST=1 "
+            ));
+        }
 
-        command.push(format!(
-            "AFL_AUTORESUME={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::AutoResume))
-        ));
-        command.push(format!(
-            "AFL_FINAL_SYNC={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::FinalSync))
-        ));
-        command.push(format!(
-            "AFL_DISABLE_TRIM={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::DisableTrim))
-        ));
-        command.push(format!(
-            "AFL_KEEP_TIMEOUTS={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::KeepTimeouts))
-        ));
-        command.push(format!(
-            "AFL_EXPAND_HAVOC_NOW={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::ExpandHavocNow))
-        ));
-        command.push(format!(
-            "AFL_IGNORE_SEED_PROBLEMS={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::IgnoreSeedProblems))
-        ));
-        command.push(format!(
-            "AFL_IMPORT_FIRST={} ",
-            u8::from(self.is_flag_enabled(&AFLFlag::ImportFirst))
-        ));
         command.push(format!("AFL_TESTCACHE_SIZE={} ", self.testcache_size));
 
         command

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 /// Default corpus directory
@@ -133,6 +133,15 @@ pub struct GenArgs {
         required = false
     )]
     pub config: Option<PathBuf>,
+    /// Use AFL-Fuzz defaults
+    #[arg(
+        short = 'd',
+        long,
+        help = "Use afl-fuzz defaults power schedules, queue and mutation strategies",
+        required = false,
+        action = ArgAction::SetTrue
+    )]
+    pub use_afl_defaults: bool,
 }
 
 impl GenArgs {
@@ -218,6 +227,7 @@ impl GenArgs {
                 .afl_binary
                 .clone()
                 .or_else(|| config.afl_cfg.afl_binary.clone().filter(|b| !b.is_empty())),
+            use_afl_defaults: config.afl_cfg.use_afl_defaults.unwrap_or(self.use_afl_defaults),
             config: self.config.clone(),
         }
     }
@@ -355,6 +365,8 @@ pub struct AflConfig {
     pub dictionary: Option<String>,
     /// Additional AFL flags
     pub afl_flags: Option<String>,
+    /// Use AFL defaults
+    pub use_afl_defaults: Option<bool>,
 }
 
 /// Configuration for tmux

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ fn create_afl_runner(
         raw_afl_flags,
         gen_args.afl_binary.clone(),
         is_ramdisk,
+        gen_args.use_afl_defaults,
     ))
 }
 


### PR DESCRIPTION
Addressing issues #40 and #38 
I changed a bit how the flags (env variables) are being added. Now it only adds the env variable if the corresponding flag is set (no need for AFL_XXX=0 IMO). This simplifies the use afl defaults feature (#40).