### PR TITLE
Allow to specify options for certain instances only

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 /// Default corpus directory
 pub const AFL_CORPUS: &str = "/tmp/afl_input";
@@ -367,6 +367,29 @@ pub struct AflConfig {
     pub afl_flags: Option<String>,
     /// Use AFL defaults
     pub use_afl_defaults: Option<bool>,
+    /// Partial AFL flags
+    pub flags_partial: AflFlagsPartial,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct AflFlagsPartial {
+    #[serde(flatten)]
+    pub global_flags: FlagGroup,
+    pub groups: Vec<FlagGroup>,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct FlagGroup {
+    pub probability: Option<f32>,
+    pub count: Option<u32>,
+    #[serde(flatten)]
+    pub flags: HashMap<String, toml::Value>,
+}
+
+impl FlagGroup {
+    pub const fn is_valid(&self) -> bool {
+        !(self.probability.is_some() && self.count.is_some())
+    }
 }
 
 /// Configuration for tmux

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -368,14 +368,7 @@ pub struct AflConfig {
     /// Use AFL defaults
     pub use_afl_defaults: Option<bool>,
     /// Partial AFL flags
-    pub flags_partial: AflFlagsPartial,
-}
-
-#[derive(Debug, Deserialize, Clone, Default)]
-pub struct AflFlagsPartial {
-    #[serde(flatten)]
-    pub global_flags: FlagGroup,
-    pub groups: Vec<FlagGroup>,
+    pub flags_partial: Vec<FlagGroup>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -111,13 +111,7 @@ pub fn load_config(config_path: Option<&PathBuf>) -> Result<Config> {
 }
 
 fn validate_config(config: &Config) -> Result<()> {
-    if !config.afl_cfg.flags_partial.global_flags.is_valid() {
-        return Err(anyhow::anyhow!(
-            "Error: partial flags has both `probability` and `count`, which are mutually exclusive"
-        ));
-    }
-
-    for (i, group) in config.afl_cfg.flags_partial.groups.iter().enumerate() {
+    for (i, group) in config.afl_cfg.flags_partial.iter().enumerate() {
         if !group.is_valid() {
             return Err(anyhow::anyhow!(
                 "Error: Group {} has both `probability` and `count`, which are mutually exclusive",


### PR DESCRIPTION
Implements #39 

- [ ] Parsing of config file 
- [ ] Generating command based on the partial flags
- [ ] Add a cleanup stage after command is generated in order to merge same env variable (e.g. `AFL_PRELOAD`)
- [ ] Document TOML format 

Example TOML:
```toml
[target]
# Target binary to fuzz
path = "/bin/ls"

# Target binary arguments, including @@ if needed
args = []

[afl_cfg]
# Amount of processes to spin up
runners = 2

# Custom path to 'afl-fuzz' binary
afl_binary = "/tmp/afl-fuzz"

# Seed corpus directory
seed_dir = "/tmp/in/"

# Solution/Crash output directory
solution_dir = "/tmp/out"

# Token dictionary to use
#dictionary = "/path/to/dictionary"

# Custom AFL flags
afl_flags = "-Q"

# Use afl-fuzz defaults
use_afl_defaults = false

[[afl_cfg.flags_partial]]
probability = 0.5
AFL_USE_QASAN=1

[[afl_cfg.flags_partial]]
probability = 0.2
AFL_PRELOAD = "/path/to/libcompcov.so"
AFL_COMPCOV_LEVEL = 1

[[afl_cfg.flags_partial]]
count = 4
-x = "/tmp/dictionary1"

[[afl_cfg.flags_partial]]
count = 3
-x = "/tmp/dictionary2"

[[afl_cfg.flags_partial]]
probability = 0.4
-G = 1234

[session]
# Spin up a custom tmux session with the fuzzers
dry_run = false

# Custom tmux session name
name = "fuzz"

# Runner backend to use: [tmux, screen]
runner = "tmux"

[misc]
# Enable TUI mode

```