### PR TITLE
feat: Nyx mode

### DIFF
--- a/src/afl/cmd_gen.rs
+++ b/src/afl/cmd_gen.rs
@@ -175,17 +175,31 @@ impl AFLCmdGenerator {
 
         let target_fname = get_file_stem(&self.harness.target_bin);
 
+        if self.harness.nyx_mode {
+            cmds.iter_mut()
+                .for_each(|cmd| cmd.add_flag("-Y".to_string()));
+        }
+
         if let Some(cmd) = cmds.first_mut() {
-            match mode {
-                Mode::CIFuzzing => {
+            match (mode, self.harness.nyx_mode) {
+                (Mode::CIFuzzing, false) => {
                     cmd.add_flag(format!("-S s_{target_fname}"));
                 }
-                _ => {
+                (_, false) => {
                     cmd.add_flag(format!("-M m_{target_fname}"));
+                }
+                (_, true) => {
+                    cmd.add_flag(format!("-M 0"));
                 }
             }
         }
+
         for (i, cmd) in cmds.iter_mut().skip(1).enumerate() {
+            if self.harness.nyx_mode {
+                cmd.add_flag(format!("-S {}", i + 1));
+                continue;
+            }
+
             let suffix = if cmd.misc_afl_flags.iter().any(|f| f.contains("-c")) {
                 format!("_{target_fname}_cl")
             } else {
@@ -260,6 +274,7 @@ mod tests {
             cmpcov_bin: None,
             target_args: None,
             cov_bin: None,
+            nyx_mode: false,
         }
     }
 

--- a/src/afl/coverage.rs
+++ b/src/afl/coverage.rs
@@ -514,7 +514,7 @@ impl CoverageCollector {
 
         // Create temporary directory for batch processing
         let temp_dir = TempDir::new()?;
-        
+
         // Process files in parallel batches
         let temp_merged_files: Result<Vec<_>> = profraw_files
             .par_chunks(1000)

--- a/src/cli/afl.rs
+++ b/src/cli/afl.rs
@@ -18,4 +18,6 @@ pub struct AflArgs {
     pub afl_flags: Option<String>,
     /// Mode to generate commands
     pub mode: Option<Mode>,
+    /// Nyx mode
+    pub nyx_mode: Option<bool>,
 }

--- a/src/cli/gen.rs
+++ b/src/cli/gen.rs
@@ -29,6 +29,10 @@ pub struct GenArgs {
     #[arg(help = "Target binary arguments, including @@ if needed", raw = true)]
     pub target_args: Option<Vec<String>>,
 
+    /// Nyx mode toggle
+    #[arg(long, help = "Use AFL++'s Nyx mode", action = ArgAction::SetTrue)]
+    pub nyx_mode: bool,
+
     /// Amount of processes to spin up
     #[arg(
         short = 'n',

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -108,6 +108,7 @@ impl ArgMerge<Self> for GenArgs {
             seed: self.seed.or(args.misc.seed),
             use_seed_afl: args.misc.use_seed_afl.unwrap_or(self.use_seed_afl),
             config: self.config.clone(),
+            nyx_mode: args.afl_cfg.nyx_mode.unwrap_or(self.nyx_mode),
         }
     }
 }

--- a/src/commands/gen.rs
+++ b/src/commands/gen.rs
@@ -37,6 +37,7 @@ impl<'a> GenCommand<'a> {
         let harness = Harness::new(
             gen_args.target.clone().unwrap(),
             gen_args.target_args.clone(),
+            gen_args.nyx_mode,
         )?
         .with_sanitizer(gen_args.san_target.clone())?
         .with_cmplog(gen_args.cmpl_target.clone())?

--- a/src/commands/render_tui.rs
+++ b/src/commands/render_tui.rs
@@ -19,7 +19,7 @@ impl<'a> RenderCommand<'a> {
     fn validate_output_dir(output_dir: &Path) -> Result<()> {
         for entry in output_dir.read_dir()? {
             let path = entry?.path();
-            if path.is_dir() {
+            if path.is_dir() && !path.to_str().unwrap().contains("workdir") {
                 let fuzzer_stats = path.join("fuzzer_stats");
                 if !fuzzer_stats.exists() {
                     bail!(


### PR DESCRIPTION
This PR implements support for [Nyx mode](https://github.com/AFLplusplus/AFLplusplus/blob/stable/nyx_mode/README.md).

Adds a new `--nyx-mode` option for `run` and `gen` that enables nyx mode. Under nyx mode all target paths are expected to be an existing nyx share directory. Code coverage and cmplog are not supported. 